### PR TITLE
Allow models with circular relations to be constructed with createRelations=false

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,4 +193,4 @@ model.dot('nestedModel1.nestedCollection2.nestedIdOfModel3').get('foo.bar');
 
 | Key | Default | Description |
 | --- | ------- | ----------- |
-| createRelations | `true` |  `true`: create relations while initializing model. `false`: skip creating relations upon initialization. NOTE: when using `set`, this option is ignored. Relations will always be intialized when using set. |
+| createRelations | `true` |  `true`: create relations while initializing model. `false`: skip creating relations upon initialization. |

--- a/index.js
+++ b/index.js
@@ -31,14 +31,16 @@ export default Backbone.Model.extend({
     relations: {},
     constructor: function Constructor(attributes, options) {
         options || (options = {});
-        const createRelations = options.createRelations !== undefined ? options.createRelations : this.createRelations;
+        if (typeof options.createRelations !== 'undefined') {
+            this.createRelations = options.createRelations;
+        }
         const relations = _.result(this, 'relations');
 
         // We take attributes directly, because a toJSON call might translate
         // the model's attributes...
         let attrs = attributes instanceof BM ? attributes.attributes : attributes;
 
-        if (createRelations && !_.isEmpty(relations)) {
+        if (this.createRelations && !_.isEmpty(relations)) {
             attrs || (attrs = {});
 
             // Create all relations for the first time.
@@ -167,6 +169,10 @@ export default Backbone.Model.extend({
     setRelated(attributes, options) {
         const changes = [];
         const omit = [];
+
+        options = _.extend({
+            createRelations: this.createRelations,
+        }, options || {});
 
         // Find attributes that map to a relation.
         _.each(_.intersection(_.keys(_.result(this, 'relations')), _.keys(attributes)), (relation) => {

--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ export default Backbone.Model.extend({
             if (!(currentValue instanceof constructor)) {
                 // If the current relation is not defined and a correct instance
                 // is given, set that instance directly.
-                if (newValue instanceof constructor) {
+                if (newValue instanceof constructor || !options.createRelations) {
                     attributes[relation] = newValue;
                 } else {
                     attributes[relation] = this.createRelated(relation, newValue, constructor, options);

--- a/test/relation.js
+++ b/test/relation.js
@@ -244,6 +244,146 @@ QUnit.test('defining advanced relation', 1, (assert) => {
     assert.equal(mPost.dot('author.name'), 'Burhan');
 });
 
+QUnit.test('related models should not be instantiated if createRelations=false', 1, (assert) => {
+    const MGrandParent = Backbone.Model.extend();
+    const MParent = Backbone.Model.extend({
+        relations: {
+            grandParent: MGrandParent,
+        },
+    });
+    const MChild = Backbone.Model.extend({
+        relations: {
+            parent: MParent,
+        },
+    });
+
+    const mChild = new MChild(null, { createRelations: false });
+    assert.strictEqual(mChild.dot('parent'), undefined);
+});
+
+
+QUnit.test('the createRelations=false option should not have any effect on .set', 4, (assert) => {
+    // Zaico said that "createRelations" should have been called "createEmptyRelations",
+    // i.e. that the option should only control whether an empty model will be instantiated.
+    // This test verifies that the relation-creation behavior is not influenced by the
+    // "createRelations" option.
+    //
+    // This distinction makes no sense because any attributes passed to the constructor
+    // (either via the constructor parameter, or via defaults) will be assigned using .set.
+    // As a result, if a model has a default attribute AND the attribute is part of a circular
+    // model dependency, then such a model can never be instantiated, even if createRelations=false.
+    //
+    // [ other skipped tests will refer to the above notes as NOTE_BAD_LOGIC ]
+    const MGrandParent = Backbone.Model.extend();
+    const MParent = Backbone.Model.extend({
+        relations: {
+            grandParent: MGrandParent,
+        },
+    });
+    const MChild = Backbone.Model.extend({
+        relations: {
+            parent: MParent,
+        },
+    });
+
+    const mChild = new MChild(null, { createRelations: false });
+    mChild.set({ parent: { grandParent: 1 } });
+    assert.ok(mChild.dot('parent') instanceof MParent);
+    assert.ok(mChild.dot('parent.grandParent') instanceof MGrandParent);
+
+    mChild.set({ parent: { grandParent: 3 } }, { createRelations: false });
+    assert.ok(mChild.dot('parent') instanceof MParent);
+    assert.ok(mChild.dot('parent.grandParent') instanceof MGrandParent);
+});
+
+QUnit.test('should not crash on circular models with createRelations=false', 2, (assert) => {
+    const MCircular = Backbone.Model.extend({
+        relations() {
+            return {
+                prop: MCircular,
+            };
+        },
+    });
+    const mCircular = new MCircular(null, { createRelations: false });
+    assert.strictEqual(mCircular.get('prop'), undefined);
+
+    mCircular.set({ prop: 456 });
+    // Once NOTE_BAD_LOGIC is fixed, the below assertion should be changed to the commented-out one,
+    assert.ok(mCircular.get('prop') instanceof MCircular);
+    // assert.strictEqual(mCircular.get('prop'), 456);
+});
+
+// Skipped because test fails, see NOTE_BAD_LOGIC.
+QUnit.skip('should not crash on circular models with default values and createRelations=false', 2, (assert) => {
+    const MCircular = Backbone.Model.extend({
+        defaults: {
+            prop: 123,
+        },
+        relations() {
+            return {
+                prop: MCircular,
+            };
+        },
+    });
+    const mCircular = new MCircular(null, { createRelations: false });
+    assert.equal(mCircular.get('prop'), 123);
+
+    mCircular.set({ prop: 456 });
+    assert.equal(mCircular.get('prop'), 456);
+});
+
+QUnit.test('circular models with createRelations=true cannot be created', 1, (assert) => {
+    const MCircular = Backbone.Model.extend({
+        relations() {
+            return {
+                prop: MCircular,
+            };
+        },
+    });
+    assert.throws(() => {
+        // eslint-disable-next-line no-new
+        new MCircular(null, { createRelations: true });
+    }, 'A model with a circular dependency cannot be instantiated with createRelations=true');
+});
+
+QUnit.test('circular models cannot be assigned a value with createRelations=true', 3, (assert) => {
+    const MCircular = Backbone.Model.extend({
+        relations() {
+            return {
+                prop: MCircular,
+            };
+        },
+    });
+    const mCircular = new MCircular(null, { createRelations: false });
+    assert.strictEqual(mCircular.get('prop'), undefined);
+    assert.throws(() => {
+        mCircular.set({ prop: 789 }, { createRelations: true });
+    }, '.set with createRelations=true on a circular model should throw');
+
+    assert.strictEqual(mCircular.get('prop'), undefined);
+});
+
+// Skipped because test fails, see NOTE_BAD_LOGIC.
+QUnit.skip('circular models with default attributes cannot be assigned a value with createRelations=true', 3, (assert) => {
+    const MCircular = Backbone.Model.extend({
+        defaults: {
+            prop: 567,
+        },
+        relations() {
+            return {
+                prop: MCircular,
+            };
+        },
+    });
+    const mCircular = new MCircular(null, { createRelations: false });
+    assert.equal(mCircular.get('prop'), 567);
+    assert.throws(() => {
+        mCircular.set({ prop: 789 }, { createRelations: true });
+    }, '.set with createRelations=true on a circular model should throw');
+
+    assert.equal(mCircular.get('prop'), 567);
+});
+
 QUnit.test('a change on a relation should trigger a change', 1, (assert) => {
     const mPost = new MPost();
     let cnt = 0;


### PR DESCRIPTION
@abzainuddin Please review the changes.
The desire to automagically instantiate the model in the `.set` method even when the model is constructed with `createRelations=false` does not make sense. See the commit description of the first commit.

(all tests currently pass with these changes)